### PR TITLE
feat: add 3 days minimum release age for pnpm packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 4320


### PR DESCRIPTION
Set minimum release age to 3 days in pnpm-workspace.yaml

```typescript
minimumReleaseAge: 4320
``` 

Value measured in minutes as explained in [pnpm docs](https://pnpm.io/settings#minimumreleaseage)